### PR TITLE
chore: align rspack optimization with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "sass-loader": "^14.2.1",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.4.2",
+    "terser-webpack-plugin": "5.3.10"
   },
   "resolutions": {
     "@rspack/cli": "1.0.0-alpha.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       sass-loader:
         specifier: ^14.2.1
         version: 14.2.1(@rspack/core@1.0.0-alpha.0(@swc/helpers@0.5.11))(sass-embedded@1.77.5)(sass@1.76.0)(webpack@5.91.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(esbuild@0.19.12))
+      terser-webpack-plugin:
+        specifier: 5.3.10
+        version: 5.3.10(@swc/core@1.3.107(@swc/helpers@0.5.11))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(esbuild@0.19.12))
       ts-jest:
         specifier: ^29.1.0
         version: 29.1.2(@babel/core@7.24.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(esbuild@0.19.12)(jest@29.7.0(@types/node@18.16.9)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.11))(@types/node@18.16.9)(typescript@5.4.5)))(typescript@5.4.5)

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -3,15 +3,28 @@ const {
   HtmlRspackPlugin,
   SwcJsMinimizerRspackPlugin,
   CopyRspackPlugin,
+  javascript,
 } = require('@rspack/core');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const lightningcss = require('lightningcss');
 const browserslist = require('browserslist');
+const terserPlugin = require('terser-webpack-plugin');
 const { AngularWebpackPlugin } = require('@ngtools/webpack');
 const { ProgressPlugin, CssExtractRspackPlugin } = require('@rspack/core');
 const {
   getSupportedBrowsers,
+  
 } = require('@angular-devkit/build-angular/src/utils/supported-browsers');
+const {
+  JavaScriptOptimizerPlugin,
+} = require('@angular-devkit/build-angular/src/tools/webpack/plugins/javascript-optimizer-plugin');
+const {
+  TransferSizePlugin
+} = require('@angular-devkit/build-angular/src/tools/webpack/plugins/transfer-size-plugin');
+const {
+  CssOptimizerPlugin
+} = require('@angular-devkit/build-angular/src/tools/webpack/plugins/css-optimizer-plugin');
+
 const path = require('path');
 
 /**
@@ -151,15 +164,19 @@ module.exports = composePlugins(withNx(), withWeb(), (baseConfig, ctx) => {
     optimization: {
       minimize: true,
       minimizer: [
-        new SwcJsMinimizerRspackPlugin(),
-        new CssMinimizerPlugin({
-          minify: CssMinimizerPlugin.lightningCssMinify,
-          minimizerOptions: {
-            targets: lightningcss.browserslistToTargets(
-              browserslist(supportedBrowsers)
-            ),
+        new JavaScriptOptimizerPlugin({
+          advanced:true,
+          define: {
+            ngDevMode: false,
+            ngI18nClosureMode: false,
+            ngJitMode:false
           },
+          keepIdentifierNames:false,
+          removeLicenses:true,
+          sourcemap:false,
         }),
+        new TransferSizePlugin(),
+        new CssOptimizerPlugin({})
       ],
     },
     plugins: [


### PR DESCRIPTION
after align optimization with webpack, rspack & webpack size is nearly the same
![image](https://github.com/edbzn/ng-rspack/assets/8898718/924f43c7-bcc9-4bec-8269-59c69e8c6140)
